### PR TITLE
Uniform version number

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "rfc3161-client"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "asn1",
  "cryptography-x509",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rfc3161-client"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 authors = [
     "Trail of Bits <opensource@trailofbits.com>"


### PR DESCRIPTION
Before publishing the first version of the package, let uniform our version numbers.