### PR TITLE
CI: drop macos-ci-jobs env

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -128,7 +128,6 @@ jobs:
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
-    environment: macos-ci-jobs
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
I've deleted this environment.