### PR TITLE
Fix project version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Typing :: Typed",
 ]
-dynamic = ["version"]
+# Maturin does not support dynamic fields
+# So we keep the version number here (and in __init__.py)
+version = "0.0.1"
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Trail of Bits", email = "opensource@trailofbits.com" }]


### PR DESCRIPTION
Maturin defines the project version using:

- `Cargo.toml` (in our case `rust/Cargo.toml`)
- `pyproject.toml`

However, it does not support [dynamic fields](https://github.com/PyO3/maturin/blob/83c7dd282e18026b7bb4fccd1f31f61f42b96abf/src/metadata.rs#L139-L141).

So we fix the version here to generate the appropriate wheel.