### PR TITLE
Add magic method

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -96,6 +96,22 @@ impl TimeStampReq {
             Err(e) => Err(pyo3::exceptions::PyValueError::new_err(format!("{e}"))),
         }
     }
+    
+    fn __hash__(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        let buffer = asn1::write_single(&self.raw.borrow_dependent()).unwrap();
+        buffer.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn __repr__(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
+        let version = self.version()?;
+        let nonce_repr = match self.nonce(py)? {
+            Some(n) => n.to_string(),
+            None => "None".to_string(),
+        };
+        Ok(format!("<TimestampRequest(version={version}, nonce={nonce_repr})>"))
+    }
 }
 
 self_cell::self_cell!(
@@ -278,7 +294,7 @@ impl TimeStampResp {
         hasher.finish()
     }
 
-    fn __repr__(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<String> {
+    fn __repr__(&self) -> pyo3::PyResult<String> {
         let status = self.status()?;
         Ok(format!("<TimestampResponse(status={status}, ...)>"))
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -96,7 +96,7 @@ impl TimeStampReq {
             Err(e) => Err(pyo3::exceptions::PyValueError::new_err(format!("{e}"))),
         }
     }
-    
+
     fn __hash__(&self) -> u64 {
         let mut hasher = DefaultHasher::new();
         let buffer = asn1::write_single(&self.raw.borrow_dependent()).unwrap();
@@ -110,7 +110,9 @@ impl TimeStampReq {
             Some(n) => n.to_string(),
             None => "None".to_string(),
         };
-        Ok(format!("<TimestampRequest(version={version}, nonce={nonce_repr})>"))
+        Ok(format!(
+            "<TimestampRequest(version={version}, nonce={nonce_repr})>"
+        ))
     }
 }
 


### PR DESCRIPTION
Add `__hash__` and `__repr__` for the `TimestampReq` and `TimestampResp` object.

We cannot use the `Hash` trait because some subtypes are not implementing it.
Instead, we rely on using the serialized form of the object using `write_single`.