### PR TITLE
Update verify opts

### DIFF
--- a/src/rfc3161_client/verify.py
+++ b/src/rfc3161_client/verify.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import cryptography.x509
 from cryptography.hazmat.primitives._serialization import Encoding
@@ -14,15 +14,15 @@ from rfc3161_client.tsp import PKIStatus, TimeStampRequest, TimeStampResponse
 
 @dataclass
 class VerifyOpts:
-    policy_id: cryptography.x509.ObjectIdentifier | None
-    tsa_certificate: cryptography.x509.Certificate | None
-    intermediates: list[cryptography.x509.Certificate]
-    roots: list[cryptography.x509.Certificate]
-    nonce: int
-    common_name: str
+    policy_id: cryptography.x509.ObjectIdentifier | None =  None
+    tsa_certificate: cryptography.x509.Certificate | None = None
+    intermediates: list[cryptography.x509.Certificate] = field(default_factory=list)
+    roots: list[cryptography.x509.Certificate] = field(default_factory=list)
+    nonce: int | None = None
+    common_name: str | None = None
 
 
-def create_verify_opts(
+def create_verify_opts_from_request(
     tsp_request: TimeStampRequest,
     tsa_certificate: cryptography.x509.Certificate | None,
     common_name: str,

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -13,7 +13,7 @@ from rfc3161_client.tsp import TimeStampRequest, TimeStampResponse
 from rfc3161_client.verify import (
     VerifyOpts,
     _verify_tsr_with_chains,
-    create_verify_opts,
+    create_verify_opts_from_request,
     verify_timestamp_response,
 )
 
@@ -40,7 +40,7 @@ def ts_response() -> TimeStampResponse:
 def verify_opts(
     certificates: list[cryptography.x509.Certificate], ts_request: TimeStampRequest
 ) -> VerifyOpts:
-    return create_verify_opts(
+    return create_verify_opts_from_request(
         ts_request,
         tsa_certificate=certificates[0],
         common_name=certificates[0].subject.rfc4514_string(),
@@ -57,7 +57,7 @@ class TestVerifyOpts:
     def test_create_verify_opts(
         self, ts_request: TimeStampRequest, certificates: list[cryptography.x509.Certificate]
     ):
-        verify_opts = create_verify_opts(
+        verify_opts = create_verify_opts_from_request(
             ts_request,
             tsa_certificate=certificates[0],
             common_name=certificates[0].subject.rfc4514_string(),
@@ -72,7 +72,7 @@ class TestVerifyOpts:
     def test_without_certificates(
         self, ts_request: TimeStampRequest, certificates: list[cryptography.x509.Certificate]
     ):
-        verify_opts = create_verify_opts(
+        verify_opts = create_verify_opts_from_request(
             ts_request,
             tsa_certificate=certificates[0],
             common_name=certificates[0].subject.rfc4514_string(),


### PR DESCRIPTION
`VerifyOpts` could be partial - for instance, when we have no idea what the nonce used has been.

This modifies the `VerifyOpts` class to accept partial options.