### PR TITLE
Simplify the public API usage

### DIFF
--- a/src/rfc3161_client/__init__.py
+++ b/src/rfc3161_client/__init__.py
@@ -1,3 +1,38 @@
-"""RFC3161 Client."""
+"""rfc3161-client"""
+
+from .base import decode_timestamp_response
+from .errors import VerificationError
+from .tsp import (
+    Accuracy,
+    MessageImprint,
+    PKIStatus,
+    SignedData,
+    SignerInfo,
+    TimeStampRequest,
+    TimeStampResponse,
+    TimeStampTokenInfo,
+)
+from .verify import VerifyOpts, create_verify_opts, verify_signed_data, verify_timestamp_response
+
+__all__ = [
+    # From base.py
+    "decode_timestamp_response",
+    # From verify.py
+    "verify_signed_data",
+    "verify_timestamp_response",
+    "create_verify_opts",
+    "VerifyOpts",
+    # From errors.py
+    "VerificationError",
+    # From tsp.py
+    "TimeStampRequest",
+    "TimeStampResponse",
+    "TimeStampTokenInfo",
+    "MessageImprint",
+    "PKIStatus",
+    "Accuracy",
+    "SignedData",
+    "SignerInfo",
+]
 
 __version__ = "0.0.1"

--- a/src/rfc3161_client/__init__.py
+++ b/src/rfc3161_client/__init__.py
@@ -15,16 +15,12 @@ from .tsp import (
 from .verify import VerifyOpts, create_verify_opts, verify_signed_data, verify_timestamp_response
 
 __all__ = [
-    # From base.py
     "decode_timestamp_response",
-    # From verify.py
     "verify_signed_data",
     "verify_timestamp_response",
     "create_verify_opts",
     "VerifyOpts",
-    # From errors.py
     "VerificationError",
-    # From tsp.py
     "TimeStampRequest",
     "TimeStampResponse",
     "TimeStampTokenInfo",

--- a/src/rfc3161_client/base.py
+++ b/src/rfc3161_client/base.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import enum
+from typing import TYPE_CHECKING
 
-from rfc3161_client import _rust, tsp
-from rfc3161_client._rust import verify as _rust_verify
+from rfc3161_client import _rust
+
+if TYPE_CHECKING:
+    from rfc3161_client.tsp import TimeStampRequest, TimeStampResponse
 
 
 class HashAlgorithm(enum.Enum):
@@ -67,7 +70,7 @@ class TimestampRequestBuilder:
 
         return TimestampRequestBuilder(self._data, self._algorithm, nonce, self._cert_req)
 
-    def build(self) -> tsp.TimeStampRequest:
+    def build(self) -> TimeStampRequest:
         """Build a TimestampRequest."""
         if self._data is None:
             msg = "Data must be for a Timestamp Request."
@@ -83,20 +86,6 @@ class TimestampRequestBuilder:
         )
 
 
-def decode_timestamp_response(data: bytes) -> tsp.TimeStampResponse:
+def decode_timestamp_response(data: bytes) -> TimeStampResponse:
     """Decode a Timestamp response."""
     return _rust.parse_timestamp_response(data)
-
-
-def verify_signed_data(sig: bytes, certificates: set[bytes]) -> None:
-    """Verify signed data.
-
-    This function verify that the bytes used a signature are signed by a certificate
-    trusted in the `certificates` list.
-    The function does not return anything, but raises an exception if the verification fails.
-
-    :param sig: Bytes of a PKCS7 object. This must be in DER format and will be unserialized.
-    :param certificates: A list of trusted certificates to verify the response against.
-    :raise: ValueError if the signature verification fails.
-    """
-    return _rust_verify.pkcs7_verify(sig, list(certificates))

--- a/src/rfc3161_client/verify.py
+++ b/src/rfc3161_client/verify.py
@@ -48,7 +48,7 @@ def create_verify_opts(
 def verify_signed_data(sig: bytes, certificates: set[bytes]) -> None:
     """Verify signed data.
 
-    This function verify that the bytes used a signature are signed by a certificate
+    This function verifies that the bytes used in a signature are signed by a certificate
     trusted in the `certificates` list.
     The function does not return anything, but raises an exception if the verification fails.
 

--- a/src/rfc3161_client/verify.py
+++ b/src/rfc3161_client/verify.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 import cryptography.x509
 from cryptography.hazmat.primitives._serialization import Encoding
 
-from rfc3161_client.base import verify_signed_data
+from rfc3161_client._rust import verify as _rust_verify
 from rfc3161_client.errors import VerificationError
 from rfc3161_client.tsp import PKIStatus, TimeStampRequest, TimeStampResponse
 
@@ -43,6 +43,20 @@ def create_verify_opts(
         nonce=tsp_request.nonce,
         common_name=common_name,
     )
+
+
+def verify_signed_data(sig: bytes, certificates: set[bytes]) -> None:
+    """Verify signed data.
+
+    This function verify that the bytes used a signature are signed by a certificate
+    trusted in the `certificates` list.
+    The function does not return anything, but raises an exception if the verification fails.
+
+    :param sig: Bytes of a PKCS7 object. This must be in DER format and will be unserialized.
+    :param certificates: A list of trusted certificates to verify the response against.
+    :raise: ValueError if the signature verification fails.
+    """
+    return _rust_verify.pkcs7_verify(sig, list(certificates))
 
 
 def _verify_leaf_certs(tsp_response: TimeStampResponse, opts: VerifyOpts) -> bool:


### PR DESCRIPTION
This PR ease the usage of the public API.

New: 
```python
 from rfc3161_client import VerifyOpts, TimestampRequestBuilder

request_builder = TimestampRequestBuilder() # ...
opts = VerifyOpts()
```

Old:

```python
from rfc3161_client.verify import VerifyOpts
from rfc3161_client.base import TimestampRequestBuilder

request_builder = TimestampRequestBuilder() # ...
opts = VerifyOpts()
```

It also moves `verify_signed_data` to `verify.py`