### PR TITLE
Remove dependency on maturin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Moved `maturin` dependency from main project dependencies to development dependencies
+  since it's only needed for development tasks ([88](https://github.com/trailofbits/rfc3161-client/pull/88))
+
 ## [0.1.1] - 2024-12-10
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ version = "0.1.1"
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Trail of Bits", email = "opensource@trailofbits.com" }]
-dependencies = ["maturin>=1.7,<2.0", "cryptography>=44,<45"]
+dependencies = ["cryptography>=44,<45"]
 
 [project.optional-dependencies]
 doc = []
 test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
 lint = ["ruff >= 0.7,< 0.9"]
-dev = ["rfc3161-client[test,lint,doc]"]
+dev = ["rfc3161-client[test,lint,doc]", "maturin>=1.7,<2.0"]
 
 [project.urls]
 Homepage = "https://pypi.org/project/rfc3161-client"


### PR DESCRIPTION
Fixes https://github.com/trailofbits/rfc3161-client/issues/86

We keep it in `dev` target because we want to be able to run `make dev`