### PR TITLE
chore: prep 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2024-12-11
+
 ### Changed
 
 - Moved `maturin` dependency from main project dependencies to development dependencies
@@ -79,7 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This is the first alpha release of `rfc3161-client`.
 
-[Unreleased]: https://github.com/trailofbits/rfc3161-client/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/trailofbits/rfc3161-client/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/trailofbits/rfc3161-client/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/trailofbits/rfc3161-client/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/trailofbits/rfc3161-client/compare/v0.0.5...v0.1.0
 [0.0.4]: https://github.com/trailofbits/rfc3161-client/compare/v0.0.4...v0.0.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 # Maturin does not support dynamic fields
 # So we keep the version number here instead of __init__
-version = "0.1.1"
+version = "0.1.2"
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Trail of Bits", email = "opensource@trailofbits.com" }]


### PR DESCRIPTION
Preps a release that drops `maturin` from the runtime deps.