### PR TITLE
Allow verifying certs that have a valid timestamping EKU but aren't critical

### DIFF
--- a/src/rfc3161_client/verify.py
+++ b/src/rfc3161_client/verify.py
@@ -133,7 +133,8 @@ class Verifier(metaclass=abc.ABCMeta):
         self,
         timestamp_response: TimeStampResponse,
         hashed_message: bytes,
-        critical_only: bool=True) -> bool:
+        critical_only: bool = True,
+    ) -> bool:
         """Verify a timestamp response."""
 
 
@@ -161,10 +162,11 @@ class _Verifier(Verifier):
         self._common_name: str | None = common_name
 
     def verify(
-            self,
-            timestamp_response: TimeStampResponse,
-            hashed_message: bytes,
-            critical_only: bool=True) -> bool:
+        self,
+        timestamp_response: TimeStampResponse,
+        hashed_message: bytes,
+        critical_only: bool = True,
+    ) -> bool:
         """Verify a Timestamp Response.
 
         Inspired by:
@@ -199,7 +201,9 @@ class _Verifier(Verifier):
 
         return True
 
-    def _verify_leaf_certs(self, tsp_response: TimeStampResponse, critical_only: bool=True) -> bool:
+    def _verify_leaf_certs(
+        self, tsp_response: TimeStampResponse, critical_only: bool = True
+    ) -> bool:
         """
         Verify the timestamp response regarding the leaf certificate
         """

--- a/src/rfc3161_client/verify.py
+++ b/src/rfc3161_client/verify.py
@@ -129,7 +129,11 @@ class Verifier(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def verify(self, timestamp_response: TimeStampResponse, hashed_message: bytes, critical_only: bool=True) -> bool:
+    def verify(
+        self,
+        timestamp_response: TimeStampResponse,
+        hashed_message: bytes,
+        critical_only: bool=True) -> bool:
         """Verify a timestamp response."""
 
 
@@ -156,7 +160,11 @@ class _Verifier(Verifier):
         self._nonce: int | None = nonce
         self._common_name: str | None = common_name
 
-    def verify(self, timestamp_response: TimeStampResponse, hashed_message: bytes, critical_only: bool=True) -> bool:
+    def verify(
+            self,
+            timestamp_response: TimeStampResponse,
+            hashed_message: bytes,
+            critical_only: bool=True) -> bool:
         """Verify a Timestamp Response.
 
         Inspired by:
@@ -219,7 +227,7 @@ class _Verifier(Verifier):
             if extension.oid == cryptography.x509.ObjectIdentifier("2.5.29.37"):
                 valid_eku = True
                 critical_eku = extension.critical
-        
+
         if not valid_eku:
             msg = "The certificate does not contain the Timesatmping EKU extension."
             raise VerificationError(msg)

--- a/src/rfc3161_client/verify.py
+++ b/src/rfc3161_client/verify.py
@@ -229,7 +229,7 @@ class _Verifier(Verifier):
                 critical_eku = extension.critical
 
         if not valid_eku:
-            msg = "The certificate does not contain the Timesatmping EKU extension."
+            msg = "The certificate does not contain the Timestamping EKU extension."
             raise VerificationError(msg)
 
         if critical_only and not critical_eku:

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -194,7 +194,21 @@ class TestVerifier:
     ) -> None:
         monkeypatch.setattr(cryptography.x509.Certificate, "extensions", [])
         with pytest.raises(
-            VerificationError, match="The certificate does not contain the critical EKU extension"
+            VerificationError,
+            match="The certificate does not contain the Timestamping EKU extension."
+        ):
+            verifier._verify_leaf_certs(tsp_response=ts_response)
+
+    def test_verify_leaf_certs_no_critical_eku(
+        self, verifier: Verifier, ts_response: TimeStampResponse, monkeypatch: MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            cryptography.x509.Certificate,
+            "extensions",
+            [pretend.stub(critical=False, oid=cryptography.x509.ObjectIdentifier("2.5.29.37"))]
+            )
+        with pytest.raises(
+            VerificationError, match="The certificate does not contain the critical EKU extension."
         ):
             verifier._verify_leaf_certs(tsp_response=ts_response)
 

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -195,7 +195,7 @@ class TestVerifier:
         monkeypatch.setattr(cryptography.x509.Certificate, "extensions", [])
         with pytest.raises(
             VerificationError,
-            match="The certificate does not contain the Timestamping EKU extension."
+            match="The certificate does not contain the Timestamping EKU extension.",
         ):
             verifier._verify_leaf_certs(tsp_response=ts_response)
 
@@ -205,8 +205,8 @@ class TestVerifier:
         monkeypatch.setattr(
             cryptography.x509.Certificate,
             "extensions",
-            [pretend.stub(critical=False, oid=cryptography.x509.ObjectIdentifier("2.5.29.37"))]
-            )
+            [pretend.stub(critical=False, oid=cryptography.x509.ObjectIdentifier("2.5.29.37"))],
+        )
         with pytest.raises(
             VerificationError, match="The certificate does not contain the critical EKU extension."
         ):


### PR DESCRIPTION
Based on the discussion in #104, this allows you to verify certs that are valid but don't have the 'critical' EKU set.

The changes do not alter the current behaviour, that is - the default is still to fail if the critical extension is not set. But it allows downstream implementation to decide if they way to enforce the `critical` flag or not.

