### PR TITLE
export hash algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added `HashAlgorithm` to exports of the base package module.
+
 ## Fixed
 
 - Fixed spelling of `hash_algorithm` parameter in `TimestampRequestBuilder` class ([131](https://github.com/trailofbits/rfc3161-client/pull/131))

--- a/src/rfc3161_client/__init__.py
+++ b/src/rfc3161_client/__init__.py
@@ -1,6 +1,6 @@
 """rfc3161-client"""
 
-from .base import TimestampRequestBuilder, decode_timestamp_response
+from .base import TimestampRequestBuilder, HashAlgorithm, decode_timestamp_response
 from .errors import VerificationError
 from .tsp import (
     Accuracy,
@@ -17,6 +17,7 @@ from .verify import Verifier, VerifierBuilder
 __all__ = [
     "decode_timestamp_response",
     "TimestampRequestBuilder",
+    "HashAlgorithm",
     "Verifier",
     "VerifierBuilder",
     "VerificationError",

--- a/src/rfc3161_client/__init__.py
+++ b/src/rfc3161_client/__init__.py
@@ -1,6 +1,6 @@
 """rfc3161-client"""
 
-from .base import TimestampRequestBuilder, HashAlgorithm, decode_timestamp_response
+from .base import HashAlgorithm, TimestampRequestBuilder, decode_timestamp_response
 from .errors import VerificationError
 from .tsp import (
     Accuracy,


### PR DESCRIPTION
[Client support for Rekor V2: sigstore-python #289](https://github.com/sigstore/rekor-tiles/issues/289)

Exports the `HashAlgorithm`, so folks can use it directly, eg

```python
from rfc3161_client import (
    TimestampRequestBuilder,
    HashAlgorithm
)
```

Current workaround is to import from `base`.

- https://github.com/trailofbits/rfc3161-client/blob/f03372727a8d95b7acb270b4d9e778e64f0f2b75/test/test_base.py#L4