### PR TITLE
verify: public method should not expose private type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Slight refactoring of the tests to ease how to test with multiple TSA ([#145](https://github.com/trailofbits/rfc3161-client/pull/145))
 
+- Changed return value of `VerifierBuilder.build()` from `_Verifier` to `Verifier`: This is technically
+  an API change but should have minimal user impact. ([#147](https://github.com/trailofbits/rfc3161-client/pull/147))
+
 ### Fixed
 
 - Fixed spelling of `hash_algorithm` parameter in `TimestampRequestBuilder` class ([131](https://github.com/trailofbits/rfc3161-client/pull/131))

--- a/src/rfc3161_client/verify.py
+++ b/src/rfc3161_client/verify.py
@@ -104,7 +104,7 @@ class VerifierBuilder:
         builder._common_name = name
         return builder
 
-    def build(self) -> _Verifier:
+    def build(self) -> Verifier:
         """Build the Verifier."""
         if not self._roots:
             msg = "Verifier must have at least one root certificate set"


### PR DESCRIPTION
This is technically an API change but seems to be the real intent of the API: `_Verifier` is not part of public API so the return value of a public method should not be `_Verifier`.