### PR TITLE
verify: Actually expose verify_message in the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Exposed `verify_message` in the actual `Verify` interface, not just the implementation
+  ([#153](https://github.com/trailofbits/rfc3161-client/pull/153))
+
 ## [1.0.2] - 2025-05-19
 
 ### Changed

--- a/src/rfc3161_client/verify.py
+++ b/src/rfc3161_client/verify.py
@@ -135,8 +135,19 @@ class Verifier(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
+    def verify_message(self, timestamp_response: TimeStampResponse, message: bytes) -> bool:
+        """Verify a Timestamp Response over a given message
+
+        Supports timestamp responses with SHA-256, SHA-384 or SHA-512 hash algorithms.
+        """
+
+    @abc.abstractmethod
     def verify(self, timestamp_response: TimeStampResponse, hashed_message: bytes) -> bool:
-        """Verify a timestamp response."""
+        """Verify a Timestamp Response over given message digest
+
+        Note that caller is responsible for hashing the message appropriately for the
+        given timestamp response.
+        """
 
 
 class _Verifier(Verifier):


### PR DESCRIPTION
Previously we returned a _Verifier from VerifierBuilder.build(): this hid the fact that verify_message() is not actually part of the Verifier API.

Add verify_message() to the API

Fixes #152