### PR TITLE
Type check using `mypy`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ lint: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
 		interrogate -c pyproject.toml .
 	. $(VENV_BIN)/activate && \
-		mypy src test scripts
+		mypy src test
 
 .PHONY: reformat
 reformat:

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ lint: $(VENV)/pyvenv.cfg
 	cargo fmt --check --manifest-path rust/tsp-asn1/Cargo.toml
 	. $(VENV_BIN)/activate && \
 		interrogate -c pyproject.toml .
+	. $(VENV_BIN)/activate && \
+		mypy src test scripts
 
 .PHONY: reformat
 reformat:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ dependencies = ["cryptography>=43,<46"]
 
 [project.optional-dependencies]
 doc = []
-test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
-lint = ["ruff >= 0.7,< 0.12", "interrogate"]
+test = ["pytest", "pytest-cov", "pretend", "coverage[toml]", "mypy"]
+lint = ["ruff >= 0.7,< 0.12", "interrogate", "mypy"]
 dev = ["rfc3161-client[test,lint,doc]", "maturin>=1.7,<2.0"]
 
 [project.urls]
@@ -59,3 +59,17 @@ exclude_also = ["if TYPE_CHECKING:"]
 exclude = [".venv", "test", "scripts"]
 ignore-semiprivate = true
 fail-under = 100
+
+[tool.mypy]
+mypy_path = "src"
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_return_any = true
+warn_unreachable = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_decorators = true
+check_untyped_defs = true
+disallow_any_unimported = false
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = ["cryptography>=43,<46"]
 [project.optional-dependencies]
 doc = []
 test = ["pytest", "pytest-cov", "pretend", "coverage[toml]", "mypy"]
-lint = ["ruff >= 0.7,< 0.12", "interrogate", "mypy"]
+lint = ["ruff >= 0.7,< 0.12", "interrogate", "mypy", "types-requests"]
 dev = ["rfc3161-client[test,lint,doc]", "maturin>=1.7,<2.0"]
 
 [project.urls]

--- a/src/rfc3161_client/_rust/__init__.pyi
+++ b/src/rfc3161_client/_rust/__init__.pyi
@@ -26,3 +26,8 @@ def create_timestamp_request(
 def parse_timestamp_response(
     data: bytes,
 ) -> TimeStampResponse: ...
+
+
+def parse_timestamp_request(
+    data: bytes,
+) -> TimeStampRequest: ...

--- a/src/rfc3161_client/base.py
+++ b/src/rfc3161_client/base.py
@@ -50,7 +50,7 @@ class TimestampRequestBuilder:
     def hash_algorithm(self, hash_algorithm: _AllowedHashTypes) -> TimestampRequestBuilder:
         """Set the Hash algorithm used."""
         if not isinstance(hash_algorithm, HashAlgorithm):
-            msg = f"{hash_algorithm} is not a supported hash."
+            msg = f"{hash_algorithm} is not a supported hash."  # type: ignore[unreachable]
             raise TypeError(msg)
 
         return TimestampRequestBuilder(self._data, hash_algorithm, self._nonce, self._cert_req)
@@ -58,7 +58,7 @@ class TimestampRequestBuilder:
     def cert_request(self, *, cert_request: bool = False) -> TimestampRequestBuilder:
         """Set the cert request field."""
         if not isinstance(cert_request, bool):
-            msg = "Cert request must be a boolean."
+            msg = "Cert request must be a boolean."  # type: ignore[unreachable]
             raise TypeError(msg)
 
         return TimestampRequestBuilder(self._data, self._algorithm, self._nonce, cert_request)
@@ -66,7 +66,7 @@ class TimestampRequestBuilder:
     def nonce(self, *, nonce: bool = True) -> TimestampRequestBuilder:
         """Set the request policy field."""
         if not isinstance(nonce, bool):
-            msg = "Request policy must be a boolean."
+            msg = "Request policy must be a boolean."  # type: ignore[unreachable]
             raise TypeError(msg)
 
         return TimestampRequestBuilder(self._data, self._algorithm, nonce, self._cert_req)

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -51,7 +51,7 @@ class TestRequestBuilder:
 
     def test_set_algorithm(self) -> None:
         with pytest.raises(TypeError, match="is not a supported hash."):
-            TimestampRequestBuilder().hash_algorithm("invalid hash algorithm")
+            TimestampRequestBuilder().hash_algorithm("invalid hash algorithm")  # type: ignore[arg-type]
 
         # Default hash algorithm
         request = TimestampRequestBuilder().data(b"hello").build()
@@ -59,7 +59,7 @@ class TestRequestBuilder:
 
     def test_cert_request(self) -> None:
         with pytest.raises(TypeError):
-            TimestampRequestBuilder().cert_request(cert_request="not valid")
+            TimestampRequestBuilder().cert_request(cert_request="not valid")  # type: ignore[arg-type]
 
         request = TimestampRequestBuilder().cert_request(cert_request=False).data(b"hello").build()
         assert request.cert_req is False
@@ -69,7 +69,7 @@ class TestRequestBuilder:
 
     def test_nonce(self) -> None:
         with pytest.raises(TypeError):
-            TimestampRequestBuilder().nonce(nonce="not valid")
+            TimestampRequestBuilder().nonce(nonce="not valid")  # type: ignore[arg-type]
 
         request = TimestampRequestBuilder().nonce(nonce=False).data(b"hello").build()
         assert request.nonce is None


### PR DESCRIPTION
Until `ty` is stable enough, let's use `mypy` to do the type checking here.

I'm not super satisfied with the solution of forcing the type of VerifierBuilder.build() to be a `_Verifier` in the tests, but that did the job. If you have any better solution, or a recommended approach, any feedback is appreciated!

/cc @jku 