### PR TITLE
ci: fail lint when Cargo.lock drifts from Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `make lint` now fails when `Cargo.lock` is out of date with respect to `Cargo.toml`
+  ([#290](https://github.com/trailofbits/rfc3161-client/pull/290))
+
 ## [1.0.7] - 2026-07-07
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,17 @@ dev:
 	uv sync --group dev
 	uv run maturin develop --uv
 
+# Fail if `Cargo.lock` does not match the workspace manifests. Dependabot cannot
+# rewrite the `tag = ...` pin of our `cryptography-x509` git dependency
+# (dependabot/dependabot-core#13219), so it lands lockfile-only bumps that any
+# later `cargo` run silently reverts. Without this check the two files can drift
+# apart unnoticed and break `--locked` / offline builds (issue #287).
+.PHONY: lockfile
+lockfile:
+	cargo metadata --locked --format-version 1 --manifest-path Cargo.toml > /dev/null
+
 .PHONY: lint
-lint:
+lint: lockfile
 	uv sync --group lint
 	uv run ruff format --check && \
 		uv run ruff check && \

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,6 @@ dev:
 	uv sync --group dev
 	uv run maturin develop --uv
 
-# Fail if `Cargo.lock` does not match the workspace manifests. Dependabot cannot
-# rewrite the `tag = ...` pin of our `cryptography-x509` git dependency
-# (dependabot/dependabot-core#13219), so it lands lockfile-only bumps that any
-# later `cargo` run silently reverts. Without this check the two files can drift
-# apart unnoticed and break `--locked` / offline builds (issue #287).
 .PHONY: lockfile
 lockfile:
 	cargo metadata --locked --format-version 1 --manifest-path Cargo.toml > /dev/null


### PR DESCRIPTION
Guardrail for #287. Does not fix the drift itself, only makes it visible.

## Why

`Cargo.toml` pins `cryptography-x509` with `tag = "47.0.0"` under `[workspace.dependencies]`. Dependabot's Cargo workspace-manifest updater has no pattern for `tag` / `rev` pins (dependabot/dependabot-core#13219, open since October 2025), so since April 2026 every `cryptography-x509` PR here has touched `Cargo.lock` only: #255, #257, #262, #266, #269, #272, #281. Any later `cargo` run re-resolves from the manifest and reverts the lockfile, which is why the same "from 47.0.0 to ..." bump keeps being proposed and why nobody noticed.

Nothing in CI builds with `--locked`, so the mismatch is invisible until someone builds offline. v1.0.7 was tagged in that state: `tag = "47.0.0"` in `Cargo.toml`, `tag=49.0.0` in `Cargo.lock`.

## What

A `make lockfile` target running `cargo metadata --locked`, wired as a prerequisite of `make lint`. The Lint workflow already runs on every PR and on pushes to `main` and already installs a stable toolchain, so no workflow change is needed. A lockfile-only PR now fails its checks instead of merging.

## Verification

- clean lockfile: exits 0 (~15s cold, fetches the git ref and the registry index)
- the v1.0.7 lockfile: `error: cannot update the lock file ... because --locked was passed`, exit 101
- `make lint` still passes end to end

## Not in this PR

- `--locked` on the `maturin` build jobs and the sdist-based Windows build, which would stop a drifted tree from producing release wheels
- the structural fix, so Dependabot stops creating the drift: move the git dependency into the member crates' `[dependencies]` (where tag rewriting works), or `ignore` it in `.github/dependabot.yml` and bump it by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)