### PR TITLE
build(deps): bump cryptography-x509 to 49.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,8 +97,8 @@ dependencies = [
 
 [[package]]
 name = "cryptography-x509"
-version = "0.1.0"
-source = "git+https://github.com/pyca/cryptography.git?tag=47.0.0#59c5f5e4b9395f32d407f66467d59ccea9f9829f"
+version = "0.49.0"
+source = "git+https://github.com/pyca/cryptography.git?tag=49.0.0#e300bbe2f1bec75e5ee7e0ab7b196958831b3db6"
 dependencies = [
  "asn1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [workspace.dependencies]
 asn1 = "0.24.1"
-cryptography-x509 = { git = "https://github.com/pyca/cryptography.git", tag = "47.0.0" }
+cryptography-x509 = { git = "https://github.com/pyca/cryptography.git", tag = "49.0.0" }
 hex = "0.4"
 
 [workspace.package]


### PR DESCRIPTION
Move the git tag in [workspace.dependencies] from 47.0.0 to 49.0.0 and regenerate the lockfile, so both files agree on the same tag.